### PR TITLE
Feature. 찜 상품 등록 & 찜 상품 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,14 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.5'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	//querydsl 추가
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 	id 'java'
 }
 
@@ -19,6 +27,8 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
@@ -26,8 +36,33 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//querydsl 추가
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+
 }
 
 test {
 	useJUnitPlatform()
+}
+
+//querydsl 추가 시작
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/antigravity/AntigravityApplication.java
+++ b/src/main/java/antigravity/AntigravityApplication.java
@@ -1,7 +1,11 @@
 package antigravity;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
 
 @SpringBootApplication
 public class AntigravityApplication {
@@ -10,4 +14,10 @@ public class AntigravityApplication {
 		SpringApplication.run(AntigravityApplication.class, args);
 	}
 
+	@Bean
+	JPAQueryFactory jpaQueryFactory(EntityManager em) {
+		return new JPAQueryFactory(em);
+	}
+
 }
+

--- a/src/main/java/antigravity/controller/ProductController.java
+++ b/src/main/java/antigravity/controller/ProductController.java
@@ -1,8 +1,41 @@
 package antigravity.controller;
 
+import antigravity.dto.payload.ProductResponse;
+import antigravity.dto.payload.StatusResponseDto;
+import antigravity.service.ProductService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
 public class ProductController {
 
+    private ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping("/products")
+    public List<ProductResponse> liked() {
+        return productService.findProducts();
+
+    }
+
     // TODO 찜 상품 등록 API
+    @PostMapping("/products/liked/{productId}/{userId}")
+    public ResponseEntity<?> liked(@PathVariable Long productId,
+                                @PathVariable Long userId) {
+        String msg = productService.likePost(productId, userId);
+        return (msg.equals("success!"))
+                ? new ResponseEntity<>(new StatusResponseDto("성공"), HttpStatus.CREATED)
+                : new ResponseEntity<>(new StatusResponseDto(msg), HttpStatus.BAD_REQUEST);
+    }
 
     // TODO 찜 상품 조회 API
 

--- a/src/main/java/antigravity/controller/ProductController.java
+++ b/src/main/java/antigravity/controller/ProductController.java
@@ -5,6 +5,7 @@ import antigravity.dto.payload.StatusResponseDto;
 import antigravity.entity.Product;
 import antigravity.service.ProductService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,14 +35,19 @@ public class ProductController {
                                              @PathVariable Long userId) {
         String msg = productService.likePost(productId, userId);
         return (msg.equals("success!"))
-                ? new ResponseEntity<>(new StatusResponseDto("성공"), HttpStatus.CREATED)
-                : new ResponseEntity<>(new StatusResponseDto(msg), HttpStatus.BAD_REQUEST);
+                ? new ResponseEntity<>(new StatusResponseDto("성공", null), HttpStatus.CREATED)
+                : new ResponseEntity<>(new StatusResponseDto(msg,null), HttpStatus.BAD_REQUEST);
     }
 
     // TODO 찜 상품 조회 API
     @GetMapping("/products/liked")
-    public List<ProductResponse> getLikeProduct(@RequestParam(name = "liked",required = false) Boolean liked,
-                                        @PathVariable Long userId) {
-        return productService.likeGet(liked,userId);
+    public ResponseEntity<?> getLikeProduct(@RequestParam(name = "liked",required = false) Boolean liked,
+                                            @PathVariable Long userId,
+                                            Pageable pageable) {
+//        List<ProductResponse>
+        return (productService.likeGet(liked, userId, pageable) != null)
+                ? new ResponseEntity<>(new StatusResponseDto("조회 성공", productService.likeGet(liked, userId,pageable)), HttpStatus.OK)
+                : new ResponseEntity<>(new StatusResponseDto("조회 실패", null), HttpStatus.BAD_REQUEST);
+
     }
 }

--- a/src/main/java/antigravity/controller/ProductController.java
+++ b/src/main/java/antigravity/controller/ProductController.java
@@ -2,17 +2,18 @@ package antigravity.controller;
 
 import antigravity.dto.payload.ProductResponse;
 import antigravity.dto.payload.StatusResponseDto;
+import antigravity.entity.Product;
 import antigravity.service.ProductService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
+@RequestMapping("/{userId}")
 public class ProductController {
 
     private ProductService productService;
@@ -28,9 +29,9 @@ public class ProductController {
     }
 
     // TODO 찜 상품 등록 API
-    @PostMapping("/products/liked/{productId}/{userId}")
-    public ResponseEntity<?> liked(@PathVariable Long productId,
-                                @PathVariable Long userId) {
+    @PostMapping("/products/liked/{productId}")
+    public ResponseEntity<?> postLikeProduct(@PathVariable Long productId,
+                                             @PathVariable Long userId) {
         String msg = productService.likePost(productId, userId);
         return (msg.equals("success!"))
                 ? new ResponseEntity<>(new StatusResponseDto("성공"), HttpStatus.CREATED)
@@ -38,5 +39,9 @@ public class ProductController {
     }
 
     // TODO 찜 상품 조회 API
-
+    @GetMapping("/products/liked")
+    public List<ProductResponse> getLikeProduct(@RequestParam(name = "liked",required = false) Boolean liked,
+                                        @PathVariable Long userId) {
+        return productService.likeGet(liked,userId);
+    }
 }

--- a/src/main/java/antigravity/dto/RequestDto/LikePostRequestDto.java
+++ b/src/main/java/antigravity/dto/RequestDto/LikePostRequestDto.java
@@ -1,0 +1,12 @@
+package antigravity.dto.RequestDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikePostRequestDto {
+
+    private Long userId;
+    private Long productId;
+}

--- a/src/main/java/antigravity/dto/payload/ProductResponse.java
+++ b/src/main/java/antigravity/dto/payload/ProductResponse.java
@@ -1,8 +1,12 @@
-package antigravity.payload;
+package antigravity.dto.payload;
+
+import lombok.Builder;
+import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
+@Builder @Getter
 public class ProductResponse {
 
     private Long id; // 상품아이디

--- a/src/main/java/antigravity/dto/payload/StatusResponseDto.java
+++ b/src/main/java/antigravity/dto/payload/StatusResponseDto.java
@@ -9,4 +9,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class StatusResponseDto {
     private String msg;
+    private Object data;
 }

--- a/src/main/java/antigravity/dto/payload/StatusResponseDto.java
+++ b/src/main/java/antigravity/dto/payload/StatusResponseDto.java
@@ -1,0 +1,12 @@
+package antigravity.dto.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class StatusResponseDto {
+    private String msg;
+}

--- a/src/main/java/antigravity/entity/LikeProduct.java
+++ b/src/main/java/antigravity/entity/LikeProduct.java
@@ -1,0 +1,25 @@
+package antigravity.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity @Getter @NoArgsConstructor
+public class LikeProduct {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private Long userId;
+
+    private Long productId;
+    public LikeProduct(Long userId, Long productId) {
+        this.userId = userId;
+        this.productId = productId;
+    }
+}

--- a/src/main/java/antigravity/entity/LikeProduct.java
+++ b/src/main/java/antigravity/entity/LikeProduct.java
@@ -1,22 +1,19 @@
 package antigravity.entity;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity @Getter @NoArgsConstructor
 public class LikeProduct {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
+    @Column
     private Long userId;
-
+    @Column
     private Long productId;
     public LikeProduct(Long userId, Long productId) {
         this.userId = userId;

--- a/src/main/java/antigravity/entity/Product.java
+++ b/src/main/java/antigravity/entity/Product.java
@@ -1,17 +1,20 @@
 package antigravity.entity;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import lombok.*;
 
+import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
-@Builder
-@ToString
 @Getter
+@Entity
+@NoArgsConstructor
 public class Product {
 
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     private String sku;
     private String name;
@@ -20,5 +23,10 @@ public class Product {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
+    private int view;
 
+
+    public void viewCount(int count) {
+        this.view = count;
+    }
 }

--- a/src/main/java/antigravity/entity/Product.java
+++ b/src/main/java/antigravity/entity/Product.java
@@ -25,7 +25,6 @@ public class Product {
     private LocalDateTime deletedAt;
     private int view;
 
-
     public void viewCount(int count) {
         this.view = count;
     }

--- a/src/main/java/antigravity/entity/User.java
+++ b/src/main/java/antigravity/entity/User.java
@@ -1,0 +1,28 @@
+package antigravity.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity @Getter
+@Table(name = "Member")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    @Column(nullable = false)
+    private String email;
+    @Column
+    private String name;
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    @Column
+    private LocalDateTime deletedAt;
+    @Column
+    private Long productId;
+
+
+}

--- a/src/main/java/antigravity/entity/User.java
+++ b/src/main/java/antigravity/entity/User.java
@@ -1,9 +1,11 @@
 package antigravity.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity @Getter
@@ -23,6 +25,5 @@ public class User {
     private LocalDateTime deletedAt;
     @Column
     private Long productId;
-
 
 }

--- a/src/main/java/antigravity/repository/LikeProductRepository.java
+++ b/src/main/java/antigravity/repository/LikeProductRepository.java
@@ -3,7 +3,9 @@ package antigravity.repository;
 import antigravity.entity.LikeProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeProductRepository extends JpaRepository<LikeProduct, Long> {
 
-    LikeProduct findByUserId(Long userId);
+    Optional<LikeProduct> findByUserId(Long userId);
 }

--- a/src/main/java/antigravity/repository/LikeProductRepository.java
+++ b/src/main/java/antigravity/repository/LikeProductRepository.java
@@ -1,0 +1,9 @@
+package antigravity.repository;
+
+import antigravity.entity.LikeProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeProductRepository extends JpaRepository<LikeProduct, Long> {
+
+    LikeProduct findByUserId(Long userId);
+}

--- a/src/main/java/antigravity/repository/ProductRepository.java
+++ b/src/main/java/antigravity/repository/ProductRepository.java
@@ -1,32 +1,7 @@
 package antigravity.repository;
 
 import antigravity.entity.Product;
-import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@RequiredArgsConstructor
-@Repository
-public class ProductRepository {
-
-    private final NamedParameterJdbcTemplate jdbcTemplate;
-
-    // 예시 메서드입니다.
-    public Product findById(Long id) {
-        String query = "SELECT id, sku, name, price, quantity, created_at" +
-                "       FROM product WHERE id = :id";
-        MapSqlParameterSource params = new MapSqlParameterSource("id", id);
-
-        return jdbcTemplate.queryForObject(query, params, (rs, rowNum) ->
-                Product.builder()
-                        .id(rs.getLong("id"))
-                        .sku(rs.getString("sku"))
-                        .name(rs.getString("name"))
-                        .price(rs.getBigDecimal("price"))
-                        .quantity(rs.getInt("quantity"))
-                        .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
-                        .build());
-    }
-
+public interface ProductRepository extends JpaRepository<Product,Long> {
 }

--- a/src/main/java/antigravity/repository/ProductRepository.java
+++ b/src/main/java/antigravity/repository/ProductRepository.java
@@ -1,7 +1,0 @@
-package antigravity.repository;
-
-import antigravity.entity.Product;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ProductRepository extends JpaRepository<Product,Long> {
-}

--- a/src/main/java/antigravity/repository/UserRepository.java
+++ b/src/main/java/antigravity/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package antigravity.repository;
+
+import antigravity.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/antigravity/repository/custom/ProductLikeRepository.java
+++ b/src/main/java/antigravity/repository/custom/ProductLikeRepository.java
@@ -1,0 +1,4 @@
+package antigravity.repository.custom;
+
+public class ProductLikeRepository {
+}

--- a/src/main/java/antigravity/repository/custom/ProductLikeRepository.java
+++ b/src/main/java/antigravity/repository/custom/ProductLikeRepository.java
@@ -1,4 +1,0 @@
-package antigravity.repository.custom;
-
-public class ProductLikeRepository {
-}

--- a/src/main/java/antigravity/repository/custom/ProductLikeRepositoryCustom.java
+++ b/src/main/java/antigravity/repository/custom/ProductLikeRepositoryCustom.java
@@ -1,11 +1,10 @@
 package antigravity.repository.custom;
 
 import antigravity.entity.Product;
-import antigravity.entity.User;
-import com.querydsl.core.QueryResults;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ProductLikeRepositoryCustom  {
-    List<Product> likeGet(Boolean liked, Long userId);
+    List<Product> likeGet(Boolean liked, Long userId, Pageable pageable);
 }

--- a/src/main/java/antigravity/repository/custom/ProductLikeRepositoryCustom.java
+++ b/src/main/java/antigravity/repository/custom/ProductLikeRepositoryCustom.java
@@ -1,0 +1,11 @@
+package antigravity.repository.custom;
+
+import antigravity.entity.Product;
+import antigravity.entity.User;
+import com.querydsl.core.QueryResults;
+
+import java.util.List;
+
+public interface ProductLikeRepositoryCustom  {
+    List<Product> likeGet(Boolean liked, Long userId);
+}

--- a/src/main/java/antigravity/repository/custom/ProductLikeRepositoryImpl.java
+++ b/src/main/java/antigravity/repository/custom/ProductLikeRepositoryImpl.java
@@ -1,4 +1,0 @@
-package antigravity.repository.custom;
-
-public interface ProductLikeRepositoryImpl {
-}

--- a/src/main/java/antigravity/repository/custom/ProductLikeRepositoryImpl.java
+++ b/src/main/java/antigravity/repository/custom/ProductLikeRepositoryImpl.java
@@ -1,0 +1,4 @@
+package antigravity.repository.custom;
+
+public interface ProductLikeRepositoryImpl {
+}

--- a/src/main/java/antigravity/repository/custom/ProductRepository.java
+++ b/src/main/java/antigravity/repository/custom/ProductRepository.java
@@ -1,0 +1,7 @@
+package antigravity.repository.custom;
+
+import antigravity.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product,Long>,ProductLikeRepositoryCustom {
+}

--- a/src/main/java/antigravity/repository/custom/ProductRepositoryImpl.java
+++ b/src/main/java/antigravity/repository/custom/ProductRepositoryImpl.java
@@ -1,0 +1,56 @@
+package antigravity.repository.custom;
+
+import antigravity.dto.payload.ProductResponse;
+import antigravity.entity.Product;
+import antigravity.entity.QLikeProduct;
+import antigravity.entity.QUser;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static antigravity.entity.QLikeProduct.*;
+import static antigravity.entity.QProduct.product;
+import static antigravity.entity.QUser.*;
+
+public class ProductRepositoryImpl {
+    private JPAQueryFactory jpaQueryFactory;
+
+    public ProductRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
+    public List<Product> likeGet(Boolean liked, Long userId) {
+
+        List<Product> like = jpaQueryFactory
+                .selectFrom(product)
+                .leftJoin(likeProduct).on(product.id.eq(likeProduct.productId))
+                .leftJoin(user).on(likeProduct.userId.eq(user.id))
+                .where(product.deletedAt.isNull()
+                        .and(likeProduct.userId.eq(userId))
+                        .and(product.id.eq(likeProduct.productId)))
+                .fetch();
+
+        List<Product> result = new ArrayList<>();
+        for (Product likes : like) {
+            result = jpaQueryFactory
+                    .selectFrom(product)
+                    .where(product.ne(likes))
+                    .fetch();
+        }
+
+        List<Product> empty = jpaQueryFactory
+                .selectFrom(product)
+                .where(product.deletedAt.isNull())
+                .fetch();
+
+        if (liked == null) {
+            return empty;
+        } else if (liked) {
+            return like;
+        } else {
+            return result;
+        }
+    }
+}

--- a/src/main/java/antigravity/service/ProductService.java
+++ b/src/main/java/antigravity/service/ProductService.java
@@ -1,0 +1,84 @@
+package antigravity.service;
+
+import antigravity.dto.RequestDto.LikePostRequestDto;
+import antigravity.entity.LikeProduct;
+import antigravity.entity.Product;
+import antigravity.entity.User;
+import antigravity.dto.payload.ProductResponse;
+import antigravity.repository.LikeProductRepository;
+import antigravity.repository.ProductRepository;
+import antigravity.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class ProductService {
+
+    private ProductRepository productRepository;
+    private UserRepository userRepository;
+    private LikeProductRepository likeProductRepository;
+
+    public ProductService(ProductRepository productRepository,
+                          UserRepository userRepository,
+                          LikeProductRepository likeProductRepository) {
+        this.productRepository = productRepository;
+        this.userRepository = userRepository;
+        this.likeProductRepository = likeProductRepository;
+    }
+
+
+    public List<ProductResponse> findProducts() {
+        List<Product> all = productRepository.findAll();
+        List<ProductResponse> result = new ArrayList<>();
+        for (Product product : all) {
+            ProductResponse productResponse = ProductResponse.builder()
+                    .id(product.getId())
+                    .liked(null)
+                    .totalLiked(null)
+                    .createdAt(product.getCreatedAt())
+                    .name(product.getName())
+                    .price(product.getPrice())
+                    .quantity(product.getQuantity())
+                    .sku(product.getSku())
+                    .viewed(product.getView() + 1)
+                    .build();
+            result.add(productResponse);
+        }
+        return result;
+    }
+
+    @Transactional
+    public String likePost(Long productId, Long userId) {
+        Optional<User> userTarget = userRepository.findById(userId);
+        Optional<Product> productTarget = productRepository.findById(productId);
+        LikeProduct target = likeProductRepository.findByUserId(userId);
+
+//        유저 존재여부 검증
+        if (userTarget.isEmpty() || userTarget.get().getDeletedAt() != null) {
+            return "존재하지 않는 유저입니다.";
+        }
+//        제품 존재여부 검증
+        if (productTarget.isEmpty() || productTarget.get().getDeletedAt() != null) {
+            return "존재하지 않는 제품입니다.";
+        }
+//        이미 찜했는지 검증
+        if (target != null) {
+            if (target.getProductId().equals(productId)) {
+                return "이미 찜한 제품입니다.";
+            }
+        }
+//        조회수 증가
+        int viewPoint = productTarget.get().getView();
+        productTarget.get().viewCount(viewPoint + 1);
+
+        LikeProduct likeProduct = new LikeProduct(userId, productId);
+        likeProductRepository.save(likeProduct);
+        return "success!";
+    }
+}

--- a/src/main/java/antigravity/service/ProductService.java
+++ b/src/main/java/antigravity/service/ProductService.java
@@ -8,6 +8,7 @@ import antigravity.repository.LikeProductRepository;
 import antigravity.repository.custom.ProductRepository;
 import antigravity.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -81,9 +82,14 @@ public class ProductService {
         return "success!";
     }
 
-    public List<ProductResponse> likeGet(Boolean liked, Long userId) {
-        List<Product> products = productRepository.likeGet(liked, userId);
+    public List<ProductResponse> likeGet(Boolean liked, Long userId,Pageable pageable) {
+
+        List<Product> products = productRepository.likeGet(liked, userId, pageable);
         Optional<LikeProduct> targets = likeProductRepository.findByUserId(userId);
+        Optional<User> userTarget = userRepository.findById(userId);
+        if (userTarget.isEmpty()) {
+            return null;
+        }
 
         Long targetId = null;
         if (targets.isPresent()) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,4 @@
 database: hsqldb
-
 # Database Settings
 spring:
   datasource:
@@ -8,6 +7,9 @@ spring:
     password:
     driverClassName: org.h2.Driver
 
+  jpa:
+    defer-datasource-initialization: true
+    show-sql=true:
   # H2 Settings
   h2:
     console:

--- a/src/main/resources/hsqldb/data.sql
+++ b/src/main/resources/hsqldb/data.sql
@@ -25,10 +25,10 @@ VALUES ('G2000000521', '에어러블업 브라(VBR0945)', 73000, 10, '2022-10-11
        ('G2000000523', '기능성 등살 보정브라(VGBM110)', 99000, 10, '2022-10-11 13:02:33'),
        ('G2000000525', 'No4. 더핏세트', 51000, 10, '2021-11-11 13:02:33');
 
-INSERT INTO `user` (`email`, `name`, `deleted_at`)
+INSERT INTO `member` (`email`, `name`, `deleted_at`)
 VALUES ('user1@antigravity.kr', '회원1', '2021-10-10 16:11:23');
 
-INSERT INTO `user` (`email`, `name`)
+INSERT INTO `member` (`email`, `name`)
 VALUES ('user2@antigravity.kr', '회원2'),
        ('user3@antigravity.kr', '회원3'),
        ('user4@antigravity.kr', '회원4');

--- a/src/main/resources/hsqldb/schema.sql
+++ b/src/main/resources/hsqldb/schema.sql
@@ -1,5 +1,5 @@
 DROP TABLE `product` IF EXISTS;
-DROP TABLE `user` IF EXISTS;
+DROP TABLE `member` IF EXISTS;
 
 CREATE TABLE `product`
 (
@@ -11,15 +11,17 @@ CREATE TABLE `product`
     `created_at` datetime       NOT NULL DEFAULT current_timestamp(),
     `updated_at` datetime                DEFAULT current_timestamp(),
     `deleted_at` datetime                DEFAULT NULL,
+    `view`       int                    DEFAULT 0,
     PRIMARY KEY (`id`)
 );
 
-CREATE TABLE `user`
+CREATE TABLE `member`
 (
     `id`         bigint(20) NOT NULL AUTO_INCREMENT,
     `email`      varchar(120) NOT NULL DEFAULT '',
     `name`       varchar(45)           DEFAULT '',
     `created_at` datetime     NOT NULL DEFAULT current_timestamp(),
     `deleted_at` datetime              DEFAULT NULL,
+    `product_id` long                  DEFAULT NULL,
     PRIMARY KEY (`id`)
 );

--- a/src/test/java/antigravity/repository/ProductRepositoryTests.java
+++ b/src/test/java/antigravity/repository/ProductRepositoryTests.java
@@ -1,6 +1,7 @@
 package antigravity.repository;
 
 import antigravity.entity.Product;
+import antigravity.repository.custom.ProductRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ public class ProductRepositoryTests {
     @Test
     public void findByIdTest() {
         Long id = 1L;
-        Product product = productRepository.findById(id);
+        Product product = productRepository.findById(id).orElse(null);
         Assertions.assertNotNull(product);
     }
 


### PR DESCRIPTION
찜 상품 등록 및 조회 API 요구 사항 참고하여 기능 구현하였습니다.

JPA 및 QueryDSL 라이브러리 추가했습니다.

**리팩토링 및 설계 구조**

1. 유저와 제품의 다대다 관계 처리를 위해 가운데서 유저 아이디와 제품 아이디를 갖는 찜목록 테이블 생성

2. QueryDSL
- 쿼리문 작성 중 런타임오류 발생을 컴파일 오류로 초기에 대응하기 위해 사용
- 찜 목록조회 시 전체 데이터를 조회 후 사이즈 값 만큼 페이징 처리를 하기 때문에 대량의 데이터가 있을 경우 조회 시간이 길어질것을 감안하여 Slice 페이징 처리

3. API 호출 시 결과 상태에 따른 HTTP Status 표기를 위한 ResponseEntity 사용 